### PR TITLE
Fixed typo in generated config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -133,7 +133,7 @@ if [ $selected ]; then
     sed 's/[ 	<>]//g' | sed 's/name://g')
 
     #Set config and apply default device
-    set_config "ouput" $selected
+    set_config "output" $selected
     pacmd "set-default-sink $found"
 fi
 


### PR DESCRIPTION
The generated config had a typo, resulting in a failure at load time.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>