### PR TITLE
Fixed pacmd call for setting output

### DIFF
--- a/run_goxlr.sh
+++ b/run_goxlr.sh
@@ -82,7 +82,7 @@ pactl set-card-profile alsa_card.usb-TC-Helicon_GoXLR-00 output:multichannel-out
 
 #Set default output device
 #Find current index name from config name, trim unneeded characters, set default
-found=$(pacmd list-sink | grep -E "$ouput|name:" | grep -B 1 $ouput | sed '/'$ouput'/d' | sed 's/[ 	<>]//g' | sed 's/name://g')
+found=$(pacmd list-sinks | grep -E "$ouput|name:" | grep -B 1 $ouput | sed '/'$ouput'/d' | sed 's/[ 	<>]//g' | sed 's/name://g')
 pacmd "set-default-sink $found"
 
 #Set default input device


### PR DESCRIPTION
I got errors when trying to set the default sink. Turned out, that the pacmd command contained a typo.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>