### PR TITLE
Removed the sudo run requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ These commands must be executed in the console. To do this, open the terminal, p
 ```
 wget https://github.com/GoXLR-on-Linux/goxlr-on-linux/raw/main/install.sh
 sudo chmod +x ./install.sh
-sudo ./install.sh
+sh ./install.sh
 ```
 The script should request your configuration and save it.
 


### PR DESCRIPTION
Running the script as sudo results in the run_goxlr.sh script getting placed into the root user's profile, rather than the active users. preventing auto startup.

I've also forced sh usage, as zsh sometimes doesn't shell things up propertly.